### PR TITLE
Enable linting on Windows

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -23,7 +23,7 @@ class Lintr(Linter):
         '--restore',
         '--no-save',
         '-e',
-        '"packageVersion(\'lintr\')"'
+        'packageVersion(\'lintr\')'
     ]
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.1.0'

--- a/linter.py
+++ b/linter.py
@@ -14,6 +14,7 @@ from SublimeLinter.lint import Linter, util
 
 
 class Lintr(Linter):
+
     """Provides an interface to lintr R package."""
 
     syntax = ['r', 'enhanced-r']

--- a/linter.py
+++ b/linter.py
@@ -11,6 +11,7 @@
 """This module exports the Lintr plugin class."""
 
 from SublimeLinter.lint import Linter, util
+import os
 
 
 class Lintr(Linter):
@@ -19,7 +20,16 @@ class Lintr(Linter):
 
     syntax = ['r', 'enhanced-r']
     executable = 'R'
-    version_args = '--slave --restore --no-save -e "packageVersion(\\\"lintr\\\")"'
+    if os.name == 'nt':
+        version_args = [
+            '--slave',
+            '--restore',
+            '--no-save',
+            '-e',
+            'packageVersion(\'lintr\')'
+        ]
+    else:
+        version_args = '--slave --restore --no-save -e "packageVersion(\\\"lintr\\\")"'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.1.0'
     defaults = {

--- a/linter.py
+++ b/linter.py
@@ -14,7 +14,6 @@ from SublimeLinter.lint import Linter, util
 
 
 class Lintr(Linter):
-
     """Provides an interface to lintr R package."""
 
     syntax = ['r', 'enhanced-r']

--- a/linter.py
+++ b/linter.py
@@ -11,25 +11,20 @@
 """This module exports the Lintr plugin class."""
 
 from SublimeLinter.lint import Linter, util
-import os
 
 
 class Lintr(Linter):
-
     """Provides an interface to lintr R package."""
 
     syntax = ['r', 'enhanced-r']
     executable = 'R'
-    if os.name == 'nt':
-        version_args = [
-            '--slave',
-            '--restore',
-            '--no-save',
-            '-e',
-            'packageVersion(\'lintr\')'
-        ]
-    else:
-        version_args = '--slave --restore --no-save -e "packageVersion(\\\"lintr\\\")"'
+    version_args = [
+        '--slave',
+        '--restore',
+        '--no-save',
+        '-e',
+        '"packageVersion(\'lintr\')"'
+    ]
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 0.1.0'
     defaults = {
@@ -54,7 +49,6 @@ class Lintr(Linter):
 
     def cmd(self):
         """Return a list with the command line to execute."""
-
         settings = self.get_view_settings()
         command = 'library(lintr);lint(cache = {0}, commandArgs(TRUE), {1})'.format(settings['cache'],
                                                                                     settings['linters'])


### PR DESCRIPTION
I found currently this plugin does not work on windows (I tried on Windows 7 and 10).
Execution is terminated while loading it because the command to check linter version is invalid on windows.
The problem is solved by modifying 'version_args' property of 'Lintr' class.
