### PR TITLE
Update linter.py to remove deprecated SublimeText variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --add-ignore=D202

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.3"
+  - "3.7"
 # command to install dependencies
 install:
   - pip install flake8

--- a/linter.py
+++ b/linter.py
@@ -16,16 +16,6 @@ from SublimeLinter.lint import Linter, util
 class Lintr(Linter):
     """Provides an interface to lintr R package."""
 
-    executable = 'R'
-    version_args = [
-        '--slave',
-        '--restore',
-        '--no-save',
-        '-e',
-        'packageVersion(\'lintr\')'
-    ]
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 0.1.0'
     defaults = {
         'linters': 'default_linters',
         'cache': 'TRUE',
@@ -40,11 +30,7 @@ class Lintr(Linter):
     line_col_base = (1, 1)
     tempfile_suffix = None
     error_stream = util.STREAM_BOTH
-    selectors = {}
     word_re = None
-    inline_settings = None
-    inline_overrides = None
-    comment_re = r'#'
     tempfile_suffix = 'lintr'
 
     def cmd(self):

--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,6 @@ from SublimeLinter.lint import Linter, util
 class Lintr(Linter):
     """Provides an interface to lintr R package."""
 
-    syntax = ['r', 'enhanced-r']
     executable = 'R'
     version_args = [
         '--slave',

--- a/linter.py
+++ b/linter.py
@@ -35,7 +35,7 @@ class Lintr(Linter):
 
     def cmd(self):
         """Return a list with the command line to execute."""
-        settings = self.settings()
+        settings = self.settings
         command = 'library(lintr);lint(cache = {0}, commandArgs(TRUE), {1})'.format(settings['cache'],
                                                                                     settings['linters'])
         return ['r',

--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,7 @@ class Lintr(Linter):
     defaults = {
         'linters': 'default_linters',
         'cache': 'TRUE',
-        'selector': 'source.R'
+        'selector': 'source.r'
     }
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '

--- a/linter.py
+++ b/linter.py
@@ -35,10 +35,10 @@ class Lintr(Linter):
 
     def cmd(self):
         """Return a list with the command line to execute."""
-        settings = self.get_view_settings()
+        settings = self.settings()
         command = 'library(lintr);lint(cache = {0}, commandArgs(TRUE), {1})'.format(settings['cache'],
                                                                                     settings['linters'])
-        return [self.executable_path,
+        return ['r',
                 '--slave',
                 '--restore',
                 '--no-save',

--- a/linter.py
+++ b/linter.py
@@ -28,7 +28,8 @@ class Lintr(Linter):
     version_requirement = '>= 0.1.0'
     defaults = {
         'linters': 'default_linters',
-        'cache': 'TRUE'
+        'cache': 'TRUE',
+        'selector': 'source.R'
     }
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '

--- a/linter.py
+++ b/linter.py
@@ -16,6 +16,7 @@ from SublimeLinter.lint import Linter, util
 class Lintr(Linter):
     """Provides an interface to lintr R package."""
 
+    syntax = ['r', 'enhanced-r']
     executable = 'R'
     version_args = [
         '--slave',


### PR DESCRIPTION
Modified linter.py to handle the latest version of SublimeText. Breaking on installation otherwise.