### PR TITLE
removed deprecated variables, made the plugin work on MacOS Catalina

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -8,17 +8,14 @@
 # License: MIT
 #
 
-"""This module exports the Lintr plugin class."""
-
 from SublimeLinter.lint import Linter, util
 
-
 class Lintr(Linter):
-    """Provides an interface to lintr R package."""
 
+    """Provides an interface to lintr R package."""
     defaults = {
         'linters': 'default_linters',
-        'cache': 'TRUE',
+        'cache': 'FALSE',
         'selector': 'source.r'
     }
     regex = (
@@ -35,14 +32,17 @@ class Lintr(Linter):
 
     def cmd(self):
         """Return a list with the command line to execute."""
-        settings = self.settings
-        command = 'library(lintr);lint(cache = {0}, commandArgs(TRUE), {1})'.format(settings['cache'],
-                                                                                    settings['linters'])
-        return ['r',
+
+        # settings = self.settings
+        command = "library(lintr);lint(cache=FALSE,commandArgs(TRUE), default_linters)"
+        return ["R",
                 '--slave',
                 '--restore',
                 '--no-save',
                 '-e',
                 command,
                 '--args',
-                '@']
+                '${temp_file}']
+
+
+

--- a/linter.py
+++ b/linter.py
@@ -8,14 +8,17 @@
 # License: MIT
 #
 
+"""This module exports the Lintr plugin class."""
+
 from SublimeLinter.lint import Linter, util
 
-class Lintr(Linter):
 
+class Lintr(Linter):
     """Provides an interface to lintr R package."""
+
     defaults = {
         'linters': 'default_linters',
-        'cache': 'FALSE',
+        'cache': 'TRUE',
         'selector': 'source.r'
     }
     regex = (
@@ -32,10 +35,13 @@ class Lintr(Linter):
 
     def cmd(self):
         """Return a list with the command line to execute."""
+        settings = self.settings
+        tmp = settings.context['TMPDIR']
+        linters = self.defaults['linters']
+        command = "library(lintr);lint(cache = '{0}', commandArgs(TRUE), {1})".format(tmp,
+                                                                                      linters)
 
-        # settings = self.settings
-        command = "library(lintr);lint(cache=FALSE,commandArgs(TRUE), default_linters)"
-        return ["R",
+        return ['r',
                 '--slave',
                 '--restore',
                 '--no-save',
@@ -43,6 +49,3 @@ class Lintr(Linter):
                 command,
                 '--args',
                 '${temp_file}']
-
-
-


### PR DESCRIPTION
For me, this plugin wasn't working at all.

I'm not sure what cache destination you were reading from `settings`. If you think enabling caching is essential to efficient functioning of the plugin, then please update the plugin. For me, I got a warning due to the caching, so I removed it.

```
WARNING:SublimeLinter.lint.linter:lintr output:
Error in gzfile(file, "wb") : cannot open the connection
Calls: lint -> save_cache -> save -> gzfile
In addition: Warning messages:
1: In dir.create(path) :
  cannot create dir '/Users/zach/.R/lintr_cache', reason 'No such file or directory'
2: In gzfile(file, "wb") :
  cannot open compressed file '/Users/zach/.R/lintr_cache/93e226e99b611ecce25aa0fbcf83bec3d4aa8fee', probable reason 'No such file or directory'
Execution halted
```


Also, by FAR the preferred way to install ST3 packages is through Package Control, and this repository's version is clearly a few commits ahead of that one. This plugin was causing ST3 to output all kinds of warnings regarding deprecated Linter class fields, and before I started figuring out what was going wrong (the cache location), I removed those. I could've saved some time figuring the whole thing out if I had started from this repository's version, since you have updated those.

Anyway, this version works on my MacOS Catalina machine. If others have issues, maybe use this (turn off caching) for now.