### PR TITLE
User setting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ In addition to the standard SublimeLinter settings, SublimeLinter-contrib-lintr 
 |Setting|Description|Default|
 |:------|:----------|:------|
 |linters|The custom linters you would like to use|default_linters|
+|cache|Logical or path to cache directory|TRUE|
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:

--- a/linter.py
+++ b/linter.py
@@ -36,10 +36,8 @@ class Lintr(Linter):
         """Return a list with the command line to execute."""
         settings = self.settings
 
-        command = (
-            "library(lintr);lint(cache = {0}, commandArgs(TRUE), {1})".format(
-                settings.get('cache'), settings.get('linters')
-            )
+        command = "library(lintr);lint(cache = '{0}', commandArgs(TRUE), {1})".format(
+            settings.get('cache'), settings.get('linters')
         )
 
         return [

--- a/linter.py
+++ b/linter.py
@@ -28,7 +28,6 @@ class Lintr(Linter):
     )
     multiline = False
     line_col_base = (1, 1)
-    tempfile_suffix = None
     error_stream = util.STREAM_BOTH
     word_re = None
     tempfile_suffix = 'lintr'

--- a/linter.py
+++ b/linter.py
@@ -35,16 +35,18 @@ class Lintr(Linter):
     def cmd(self):
         """Return a list with the command line to execute."""
         settings = self.settings
-        tmp = settings.context['TMPDIR']
-        linters = self.defaults['linters']
-        command = "library(lintr);lint(cache = '{0}', commandArgs(TRUE), {1})".format(tmp,
-                                                                                      linters)
 
-        return ['r',
-                '--slave',
-                '--restore',
-                '--no-save',
-                '-e',
-                command,
-                '--args',
-                '${temp_file}']
+        command = "library(lintr);lint(cache = '{0}', commandArgs(TRUE), {1})".format(
+            settings.get('cache'), settings.get('linters')
+        )
+
+        return [
+            'r',
+            '--slave',
+            '--restore',
+            '--no-save',
+            '-e',
+            command,
+            '--args',
+            '${temp_file}',
+        ]

--- a/linter.py
+++ b/linter.py
@@ -36,8 +36,10 @@ class Lintr(Linter):
         """Return a list with the command line to execute."""
         settings = self.settings
 
-        command = "library(lintr);lint(cache = '{0}', commandArgs(TRUE), {1})".format(
-            settings.get('cache'), settings.get('linters')
+        command = (
+            "library(lintr);lint(cache = {0}, commandArgs(TRUE), {1})".format(
+                settings.get('cache'), settings.get('linters')
+            )
         )
 
         return [

--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,7 @@ class Lintr(Linter):
     defaults = {
         'linters': 'default_linters',
         'cache': 'TRUE',
-        'selector': 'source.r'
+        'selector': 'source.r',
     }
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '


### PR DESCRIPTION
Fixing bugs introduced by last commit.
- linter settings used default dict preventing over-ride by user and project settings
- TMPFILE passed to cache arg of lint function

Other changes:
- Duplicate tempfile_suffix class variable with value None removed.
- Minor formatting changes applied by black.